### PR TITLE
Regression test tweaks for smaller machine testing

### DIFF
--- a/testing/regression/mcas/README.md
+++ b/testing/regression/mcas/README.md
@@ -1,8 +1,9 @@
-Regression Tests
-----------------
+# Regression Tests
 
-This directory contains a set of scripts for regresssion tests.  The tests are run with the
-following command from the build directory.
+This directory contains a set of scripts for regresssion tests.  Regression
+tests our run on an IBM internal server in response to github Pull Requests.
+
+The tests are run locally with the following command from the build directory.
 
 ./dist/testing/run-tests.sh
 
@@ -14,7 +15,7 @@ To run tests with release build do:
 
 They can also be run individually. For example,
 
-./dist/testing/test1.sh
+./dist/testing/mcas-hstore-basic-0.sh
 
 
 NOTE: Be careful not to interept tests and leave processes hanging.

--- a/testing/regression/mcas/mapstore-0.py
+++ b/testing/regression/mcas/mapstore-0.py
@@ -10,4 +10,5 @@ class mapstore_0(config_0):
 
 from sys import argv
 
+
 print(mapstore_0(argv[1]).json())

--- a/testing/regression/mcas/mcas-hstore-ado-0.sh
+++ b/testing/regression/mcas/mcas-hstore-ado-0.sh
@@ -13,7 +13,7 @@ NODE_IP="$(node_ip)"
 DEBUG=${DEBUG:-0}
 
 # launch MCAS server
-DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-ado0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP")" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
+DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-ado0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP" 11911)" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
 SERVER_PID=$!
 
 # give time to start server
@@ -22,7 +22,7 @@ sleep 3
 CLIENT_LOG="test$TESTID-client.log"
 
 # launch client
-./dist/bin/ado-test --src_addr "$NODE_IP" --server $NODE_IP --debug $DEBUG &> $CLIENT_LOG &
+./dist/bin/ado-test --src_addr "$NODE_IP" --server $NODE_IP --port 11911 --debug $DEBUG &> $CLIENT_LOG &
 CLIENT_PID=$!
 
 # arm cleanup

--- a/testing/regression/mcas/mcas-hstore-ado-sock-0.sh
+++ b/testing/regression/mcas/mcas-hstore-ado-sock-0.sh
@@ -14,7 +14,7 @@ NODE_IP="$(node_ip)"
 DEBUG=${DEBUG:-0}
 
 # launch MCAS server
-DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-ado0-sock.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP")" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
+DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-ado0-sock.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP" 11911 )" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
 SERVER_PID=$!
 
 # give time to start server
@@ -23,7 +23,7 @@ sleep 3
 CLIENT_LOG="test$TESTID-client.log"
 
 # launch client
-./dist/bin/ado-test --provider sockets --src_addr "$NODE_IP" --server $NODE_IP &> $CLIENT_LOG &
+./dist/bin/ado-test --provider sockets --src_addr "$NODE_IP" --server $NODE_IP --port 11911 &> $CLIENT_LOG &
 CLIENT_PID=$!
 
 # arm cleanup

--- a/testing/regression/mcas/mcas-hstore-basic-0.sh
+++ b/testing/regression/mcas/mcas-hstore-basic-0.sh
@@ -16,7 +16,7 @@ NODE_IP="$(node_ip)"
 DEBUG=${DEBUG:-0}
 
 # launch MCAS server
-DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP")" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
+DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP" 11911)" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
 SERVER_PID=$!
 
 sleep 3
@@ -26,7 +26,7 @@ ELEMENT_COUNT=$(scale_by_transport 2000000)
 STORE_SIZE=$((ELEMENT_COUNT*(8+VALUE_LENGTH)*80/10)) # too small
 STORE_SIZE=$((ELEMENT_COUNT*(8+VALUE_LENGTH)*84/10)) # sufficient
 CLIENT_LOG="test$TESTID-client.log"
-./dist/bin/kvstore-perf --cores "$(clamp_cpu 14)" --src_addr $NODE_IP --server $NODE_IP --test put --component mcas --elements $ELEMENT_COUNT --size $STORE_SIZE --skip_json_reporting --key_length 8 --value_length $VALUE_LENGTH --debug_level $DEBUG &> $CLIENT_LOG &
+./dist/bin/kvstore-perf --cores "$(clamp_cpu 3)" --src_addr $NODE_IP --server $NODE_IP --port 11911 --test put --component mcas --elements $ELEMENT_COUNT --size $STORE_SIZE --skip_json_reporting --key_length 8 --value_length $VALUE_LENGTH --debug_level $DEBUG &> $CLIENT_LOG &
 CLIENT_PID=$!
 
 # arm cleanup

--- a/testing/regression/mcas/mcas-hstore-basic-0.sh
+++ b/testing/regression/mcas/mcas-hstore-basic-0.sh
@@ -38,7 +38,7 @@ wait $SERVER_PID; SERVER_RC=$?
 
 # check result
 if [ "$1" == "release" ]; then
-    GOAL=185000 # was 220K
+    GOAL=200000 # test machine
 else
     GOAL=50000
 fi

--- a/testing/regression/mcas/mcas-hstore-basic-sock-0.sh
+++ b/testing/regression/mcas/mcas-hstore-basic-sock-0.sh
@@ -29,7 +29,10 @@ SOCKET_SCALE=1000
 ELEMENT_COUNT=$(scale_by_transport 2000000 $SOCKET_SCALE)
 STORE_SIZE=$((ELEMENT_COUNT*VALUE_LENGTH*24/10))
 CLIENT_LOG="test$TESTID-client.log"
-./dist/bin/kvstore-perf --provider sockets --cores "$(clamp_cpu 14)" --src_addr $NODE_IP --server $NODE_IP --test put --component mcas --elements $ELEMENT_COUNT --size $STORE_SIZE --skip_json_reporting --key_length 8 --value_length $VALUE_LENGTH --debug_level $DEBUG &> $CLIENT_LOG &
+./dist/bin/kvstore-perf --provider sockets --cores "$(clamp_cpu 14)" --src_addr $NODE_IP --server $NODE_IP \
+                        --test put --component mcas --elements $ELEMENT_COUNT \
+                        --size $STORE_SIZE --skip_json_reporting --key_length 8 --value_length $VALUE_LENGTH \
+                        --debug_level $DEBUG &> $CLIENT_LOG &
 CLIENT_PID=$!
 
 # arm cleanup

--- a/testing/regression/mcas/mcas-hstore-cc-ado-0.sh
+++ b/testing/regression/mcas/mcas-hstore-cc-ado-0.sh
@@ -13,7 +13,7 @@ NODE_IP="$(node_ip)"
 DEBUG=${DEBUG:-0}
 
 # launch MCAS server
-DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-ado0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP")" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
+DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-ado0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP" 11911 )" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
 SERVER_PID=$!
 
 # give time to start server
@@ -22,7 +22,7 @@ sleep 3
 CLIENT_LOG="test$TESTID-client.log"
 
 # launch client
-./dist/bin/ado-test --src_addr "$NODE_IP" --server $NODE_IP --debug $DEBUG &> $CLIENT_LOG &
+./dist/bin/ado-test --src_addr "$NODE_IP" --server $NODE_IP --port 11911 --debug $DEBUG &> $CLIENT_LOG &
 CLIENT_PID=$!
 
 # arm cleanup

--- a/testing/regression/mcas/mcas-hstore-cc-basic-0.sh
+++ b/testing/regression/mcas/mcas-hstore-cc-basic-0.sh
@@ -15,7 +15,7 @@ NODE_IP="$(node_ip)"
 DEBUG=${DEBUG:-0}
 
 # launch MCAS server
-DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP")" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
+DAX_RESET=1 ./dist/bin/mcas --config "$("./dist/testing/hstore-0.py" "$STORETYPE" "$DAXTYPE" "$NODE_IP" 11911)" --forced-exit --debug $DEBUG &> test$TESTID-server.log &
 SERVER_PID=$!
 
 sleep 3
@@ -25,7 +25,11 @@ ELEMENT_COUNT=$(scale_by_transport 2000000)
 STORE_SIZE=$((ELEMENT_COUNT*(8+VALUE_LENGTH)*120/10)) # too small
 STORE_SIZE=$((ELEMENT_COUNT*(8+VALUE_LENGTH)*128/10)) # sufficient
 CLIENT_LOG="test$TESTID-client.log"
-./dist/bin/kvstore-perf --cores "$(clamp_cpu 14)" --src_addr $NODE_IP --server $NODE_IP --test put --component mcas --elements $ELEMENT_COUNT --size $STORE_SIZE --skip_json_reporting --key_length 8 --value_length $VALUE_LENGTH --debug_level $DEBUG &> $CLIENT_LOG &
+
+./dist/bin/kvstore-perf --cores "$(clamp_cpu 3)" --src_addr $NODE_IP --server $NODE_IP --port 11911 \
+                        --test put --component mcas --elements $ELEMENT_COUNT --size $STORE_SIZE --skip_json_reporting \
+                        --key_length 8 --value_length $VALUE_LENGTH --debug_level $DEBUG &> $CLIENT_LOG &
+
 CLIENT_PID=$!
 
 # arm cleanup

--- a/testing/regression/mcas/mcas-hstore-cc-basic-0.sh
+++ b/testing/regression/mcas/mcas-hstore-cc-basic-0.sh
@@ -41,7 +41,7 @@ wait $SERVER_PID; SERVER_RC=$?
 
 # check result
 if [ "$1" == "release" ]; then
-    GOAL=190000 # test machine
+    GOAL=180000 # test machine
 else
     GOAL=45000
 fi

--- a/testing/regression/mcas/mcas-hstore-cc-basic-0.sh
+++ b/testing/regression/mcas/mcas-hstore-cc-basic-0.sh
@@ -41,7 +41,7 @@ wait $SERVER_PID; SERVER_RC=$?
 
 # check result
 if [ "$1" == "release" ]; then
-    GOAL=175000 # was 220K
+    GOAL=190000 # test machine
 else
     GOAL=45000
 fi

--- a/testing/regression/mcas/mcas-mapstore-basic-0.sh
+++ b/testing/regression/mcas/mcas-mapstore-basic-0.sh
@@ -37,7 +37,7 @@ wait $SERVER_PID; SERVER_RC=$?
 # check result
 
 if [ "$1" == "release" ]; then
-    GOAL=165000 # was 220K
+    GOAL=180000 # test machine threshold
 else
     GOAL=50000
 fi

--- a/testing/regression/mcas/mcas-mapstore-basic-0.sh
+++ b/testing/regression/mcas/mcas-mapstore-basic-0.sh
@@ -24,7 +24,7 @@ ELEMENT_COUNT=$(scale_by_transport 2000000)
 #STORE_SIZE=$((ELEMENT_COUNT*(8+VALUE_LENGTH)*84/10)) # too small - mapstore?
 STORE_SIZE=$((ELEMENT_COUNT*2000)) # shouldn't need this - efficiency issue?
 CLIENT_LOG="test$TESTID-client.log"
-./dist/bin/kvstore-perf --cores "$(clamp_cpu 14)" --src_addr $NODE_IP --server $NODE_IP --test put --component mcas --elements $ELEMENT_COUNT --size $STORE_SIZE --skip_json_reporting --key_length 8 --value_length $VALUE_LENGTH --debug_level $DEBUG &> $CLIENT_LOG &
+./dist/bin/kvstore-perf --cores "$(clamp_cpu 3)" --src_addr $NODE_IP --server $NODE_IP --test put --component mcas --elements $ELEMENT_COUNT --port 11911 --size $STORE_SIZE --skip_json_reporting --key_length 8 --value_length $VALUE_LENGTH --debug_level $DEBUG &> $CLIENT_LOG &
 CLIENT_PID=$!
 
 # arm cleanup

--- a/testing/regression/mcas/run-tests-minimal.sh
+++ b/testing/regression/mcas/run-tests-minimal.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+ulimit -a > ulimit.log
+env > env.log
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+. "$DIR/functions.sh"
+DELAY=4
+
+run_minimal_hstore() {
+  typeset ado_prereq="$1"
+  shift
+ # run each test
+  sleep $DELAY
+  $DIR/mcas-hstore-basic-0.sh $1
+  sleep $DELAY
+  $DIR/mcas-hstore-cc-basic-0.sh $1
+  if $ado_prereq
+  then sleep $DELAY
+    $DIR/mcas-hstore-ado-0.sh $1
+  fi
+}
+
+$DIR/mcas-mapstore-basic-0.sh $1
+if has_module_xpmem
+then sleep $DELAY
+  $DIR/mcas-mapstore-ado-0.sh $1
+fi
+sleep $DELAY
+
+if has_devdax
+then DAXTYPE=devdax run_minimal_hstore has_module_mcasmod $1
+  sleep $DELAY
+  # Conflict test, as coded, works only for devdax, not fsdax
+  # Conflict in fsdax occurs when data files exist, not when only arenas exist
+  $DIR/mcas-hstore-dax-conflict-0.sh $1
+fi
+
+if has_fsdax
+then DAXTYPE=fsdax USE_ODP=1 run_minimal_hstore true $1
+fi
+

--- a/testing/regression/mcas/shard_protos.py
+++ b/testing/regression/mcas/shard_protos.py
@@ -19,6 +19,7 @@ class shard_proto(dm):
         dm.__init__(self, {
             "core" : 0,
             "addr" : addr,
+            "port" : 11911,
         })
         self.merge(default_backend)
 


### PR DESCRIPTION
Introduction of run-tests-minimal.sh
These minimal tests will run on smaller machines with less memory (>1G PMEM) and cores (>= 4)