### PR TITLE
Perf: improvements to mpi-bench tool; set RC allocator threshold to 128K

### DIFF
--- a/src/apps/mcas-mpi-bench/mcas_mpi_bench.cpp
+++ b/src/apps/mcas-mpi-bench/mcas_mpi_bench.cpp
@@ -55,7 +55,8 @@ int main(int argc, char** argv)
   try {
     namespace po = boost::program_options;
     po::options_description desc("Options");
-    desc.add_options()("help", "Show help")
+    desc.add_options()
+      ("help", "Show help")
       ("debug", po::value<unsigned>()->default_value(0), "Debug level 0-3")
       ("patience", po::value<unsigned>()->default_value(30), "Patience with server (seconds)")
       ("server", po::value<std::string>()->default_value("10.0.0.101"), "Server network IP address")
@@ -71,6 +72,7 @@ int main(int argc, char** argv)
       ("test", po::value<std::string>()->default_value("read"), "Test 'read','write','rw50'")
       ("repeats", po::value<unsigned>()->default_value(1), "Number of experiment repeats")
       ("cps", po::value<unsigned>()->default_value(5), "Number of clients per shard (port)")
+      ("direct","Use put_direct and get_direct APIs")
       ;
 
     po::variables_map vm;
@@ -96,6 +98,7 @@ int main(int argc, char** argv)
     Options.repeats     = vm["repeats"].as<unsigned>();
     Options.port        = vm["port"].as<unsigned>();
     Options.cps         = vm["cps"].as<unsigned>();
+    Options.direct      = vm.count("direct");
   }
   catch (...) {
     std::cerr << "bad command line option configuration\n";

--- a/src/apps/mcas-mpi-bench/tasks.h
+++ b/src/apps/mcas-mpi-bench/tasks.h
@@ -54,6 +54,7 @@ public:
 protected:
   std::chrono::high_resolution_clock::time_point _start_time, _end_time;
   unsigned long                                  _iterations = 0;
+  bool                                           _first = true;
   component::Itf_ref<component::IKVStore>        _store;
   record_t *                                     _data;
   component::IKVStore::pool_t                    _pool;
@@ -98,9 +99,10 @@ public:
 
   bool do_work(unsigned rank)
   {
-    if (_iterations == 0) {
+    if (_first) {
+      _first = false;
       PINF("Starting WRITE worker: rank %u", rank);
-      _start_time = std::chrono::high_resolution_clock::now();
+      _start_time = std::chrono::high_resolution_clock::now();     
     }
 
     status_t rc;
@@ -130,7 +132,7 @@ public:
         PINF("Worker: %u complete", rank);
         return false;
       }
-      _iterations = 1;
+      _iterations = 0;
     }
     return true;
   }
@@ -194,7 +196,8 @@ public:
 
   bool do_work(unsigned rank)
   {
-    if (_iterations == 0) {
+    if (_first) {
+      _first = false;
       PINF("Starting READ worker: rank %u", rank);
       _start_time = std::chrono::high_resolution_clock::now();
     }
@@ -227,7 +230,7 @@ public:
         PINF("Worker: %u complete", rank);
         return false;
       }
-      _iterations = 1;
+      _iterations = 0;
     }
     return true;
   }
@@ -292,7 +295,8 @@ public:
 
   virtual bool do_work(unsigned rank)
   {
-    if (_iterations == 0) {
+    if (_first) {
+      _first = false;
       PINF("Starting RW50 worker: rank %u", rank);
       _start_time = std::chrono::high_resolution_clock::now();
     }
@@ -347,7 +351,7 @@ public:
         PINF("Worker: %u complete", rank);
         return false;
       }
-      _iterations = 1;
+      _iterations = 0;
     }
 
     return true;

--- a/src/apps/mcas-mpi-bench/tasks.h
+++ b/src/apps/mcas-mpi-bench/tasks.h
@@ -30,12 +30,17 @@ component::IMCAS_factory * factory = nullptr;
 
 class IOPS_base {
 public:
+
+  IOPS_base() {
+    PINF("Value size:%u", Options.value_size);
+  }
   
   unsigned long cleanup(unsigned rank)
   {
     PINF("Cleanup %u", rank);
     std::chrono::duration<double, std::milli> elapsed = _end_time - _start_time;
     auto secs = elapsed.count() / 1000.0;
+    PINF("%f seconds duration", secs);
     auto iops = double(Options.pairs * Options.repeats) / secs;
     PINF("%f iops (rank=%u)", iops, rank);
     unsigned long i_iops = boost::numeric_cast<unsigned long>(iops);

--- a/src/apps/mcas-mpi-bench/tasks.h
+++ b/src/apps/mcas-mpi-bench/tasks.h
@@ -235,9 +235,12 @@ public:
     }
 
 #ifdef MEMORY_TRANSFER_SANITY_CHECK
+    
       for(unsigned i=0;i<Options.value_size;i++) {
-        if(_value[i] != 0xA)
-          throw General_exception("memory sanity check failed");
+        if(Options.direct && _value[i] != 0xA)
+          throw General_exception("(direct) memory sanity check failed (i=%u)(data=%x)", i, _value[i]);
+        else if(reinterpret_cast<char*>(_data[_iterations].data)[i] != 0xA)
+          throw General_exception("(copy) memory sanity check failed (i=%u)(data=%x)", i, _value[i]);
       }
 #endif
 

--- a/src/apps/mcas-mpi-bench/tasks.h
+++ b/src/apps/mcas-mpi-bench/tasks.h
@@ -34,8 +34,9 @@ public:
   unsigned long cleanup(unsigned rank)
   {
     PINF("Cleanup %u", rank);
-    auto secs = std::chrono::duration<double>(_end_time - _start_time).count();
-    auto iops = (double(Options.pairs) * double(Options.repeats)) / secs;
+    std::chrono::duration<double, std::milli> elapsed = _end_time - _start_time;
+    auto secs = elapsed.count() / 1000.0;
+    auto iops = double(Options.pairs * Options.repeats) / secs;
     PINF("%f iops (rank=%u)", iops, rank);
     unsigned long i_iops = boost::numeric_cast<unsigned long>(iops);
 

--- a/src/components/api/mcas_itf.h
+++ b/src/components/api/mcas_itf.h
@@ -255,8 +255,9 @@ public:
   }
 
   /**
-   * Zero-copy put operation.  If there does not exist an object
-   * with matching key, then an error E_KEY_EXISTS should be returned.
+   * Zero-copy put operation (if value size < ~2MiB).  If there does
+   * not exist an object with matching key, then an error E_KEY_EXISTS
+   * should be returned.  Use FORCE_DIRECT=1 to force zero-copy.
    *
    * @param pool Pool handle
    * @param key Object key

--- a/src/components/client/mcas-client/src/connection.h
+++ b/src/components/client/mcas-client/src/connection.h
@@ -537,6 +537,7 @@ private:
 #endif
 
   bool     _exit;
+  bool     _force_direct = false;
   uint64_t _request_id;
 
 public: /* for async "move_along" processing */

--- a/src/components/client/mcas-client/src/mcas_client.cpp
+++ b/src/components/client/mcas-client/src/mcas_client.cpp
@@ -28,7 +28,7 @@ namespace mcas
 {
 namespace global
 {
-unsigned debug_level = 3;
+unsigned debug_level = 0;
 }
 }  // namespace mcas
 
@@ -338,9 +338,8 @@ component::IKVStore::memory_handle_t MCAS_client::register_direct_memory(void *v
    * madvise.
    */
   if (madvise(vaddr, len, MADV_DONTFORK) != 0) {
-    
-    PWRN("MCAS_client::%s: madvise MADV_DONTFORK failed (%p %lu) %s", __func__, vaddr, len, strerror(errno));
-    //    assert(false);
+    if (debug_level() > 2) 
+      PWRN("MCAS_client::%s: madvise MADV_DONTFORK failed (%p %lu) %s", __func__, vaddr, len, strerror(errno));
   }
 
   return _connection->register_direct_memory(vaddr, len);

--- a/src/components/client/mcas-client/unit_test/CMakeLists.txt
+++ b/src/components/client/mcas-client/unit_test/CMakeLists.txt
@@ -22,5 +22,12 @@ link_directories(${CMAKE_INSTALL_PREFIX}/lib64)
 add_executable(mcas-client-test1 test1.cpp)
 target_link_libraries(mcas-client-test1 ${ASAN_LIB} common numa ${GTEST_LIB} pthread dl boost_system boost_program_options)
 
-set_target_properties(mcas-client-test1 PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+set_target_properties(mcas-client-test1 PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64)
 install(TARGETS mcas-client-test1 RUNTIME DESTINATION bin)
+
+
+add_executable(mcas-client-test2 test2.cpp)
+target_link_libraries(mcas-client-test2 ${ASAN_LIB} common numa ${GTEST_LIB} pthread dl boost_system boost_program_options)
+
+set_target_properties(mcas-client-test2 PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64)
+install(TARGETS mcas-client-test2 RUNTIME DESTINATION bin)

--- a/src/components/client/mcas-client/unit_test/test2.cpp
+++ b/src/components/client/mcas-client/unit_test/test2.cpp
@@ -1,0 +1,217 @@
+/*
+   Copyright [2017-2020] [IBM Corporation]
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#define LARGE_VALUE_SIZE KB(128);  // MB(4);
+#define LARGE_ITERATIONS 10000
+#define EXPECTED_OBJECTS 10000
+
+#include <api/components.h>
+#include <api/mcas_itf.h>
+#include <common/cpu.h>
+#include <common/str_utils.h>
+#include <common/task.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#include <gtest/gtest.h>
+#pragma GCC diagnostic pop
+
+#include <sys/mman.h>
+
+#include <boost/program_options.hpp>
+#include <boost/optional.hpp>
+#include <chrono> /* milliseconds */
+#include <iostream>
+#include <thread> /* this_thread::sleep_for */
+
+//#define TEST_PERF_SMALL_PUT
+//#define TEST_PERF_SMALL_GET_DIRECT
+#define TEST_PERF_LARGE_PUT_DIRECT
+#define TEST_PERF_LARGE_GET_DIRECT
+
+//#define TEST_SCALE_IOPS
+
+// #define TEST_PERF_SMALL_PUT_DIRECT
+
+struct {
+  std::string                  addr;
+  std::string                  pool;
+  std::string                  device;
+  unsigned                     debug_level;
+  unsigned                     base_core;
+  size_t                       value_size;
+} Options{};
+
+namespace
+{
+template <typename T>
+boost::optional<T> optional_option(const boost::program_options::variables_map &vm_, const std::string &key_)
+{
+  return 0 < vm_.count(key_) ? vm_[key_].as<T>() : boost::optional<T>();
+}
+}  // namespace
+
+component::IKVStore_factory *fact;
+component::Itf_ref<component::IKVStore> _mcas;
+
+using namespace component;
+
+namespace
+{
+// The fixture for testing class Foo.
+struct mcas_client_test : public ::testing::Test {
+ protected:
+  // If the constructor and destructor are not enough for setting up
+  // and cleaning up each test, you can define the following methods:
+
+  virtual void SetUp()
+  {
+    // Code here will be called immediately after the constructor (right
+    // before each test).
+  }
+
+  virtual void TearDown()
+  {
+    // Code here will be called immediately after each test (right
+    // before the destructor).
+  }
+
+};
+
+component::Itf_ref<component::IKVStore> _mcas;
+
+
+void instantiate()
+{
+  using namespace component;
+  /* create object instance through factory */
+  IBase *comp = load_component("libcomponent-mcasclient.so", mcas_client_factory);
+
+  auto factory = static_cast<IMCAS_factory *>(comp->query_interface(IMCAS_factory::iid()));
+  assert(factory);
+
+  _mcas.reset(factory->create(Options.debug_level, "cpp_bench", Options.addr, Options.device));
+  factory->release_ref();
+}
+
+TEST_F(mcas_client_test, GetDirectWithContent)
+{
+  PMAJOR("Running OpenCloseDelete...");
+  using namespace component;
+  IKVStore::pool_t pool;
+
+  const std::string poolname = Options.pool + "/GetDirectWithContent";
+  ASSERT_TRUE((pool = _mcas->create_pool(poolname, MB(1))) != IKVStore::POOL_ERROR);
+  ASSERT_FALSE(pool == IKVStore::POOL_ERROR);
+
+  size_t size = KB(256);
+  char * buffer = static_cast<char*>(aligned_alloc(64, size));
+
+  auto handle = _mcas->register_direct_memory(buffer, size);
+  ASSERT_TRUE(handle != IMCAS::MEMORY_HANDLE_NONE);
+
+  /* populate with 0xA */
+  memset(buffer, 0xA, size);
+
+  /* put into storage */
+  std::string key = "KEY";
+  ASSERT_TRUE(_mcas->put_direct(pool,
+                                key,
+                                buffer,
+                                size,
+                                handle) == S_OK);
+
+  PMAJOR("Put direct OK (%lu)", size);
+
+  /* reset buffer */
+  memset(buffer, 0xF, size);
+
+  size_t rd_size = size;
+  ASSERT_TRUE(_mcas->get_direct(pool,
+                                key,
+                                buffer,
+                                size,
+                                handle) == S_OK);
+
+  ASSERT_TRUE(rd_size == size);
+
+  PMAJOR("Get direct OK (%lu)", rd_size);
+
+  /* check content */
+  for(size_t i=0;i<size;i++) {
+    ASSERT_TRUE(buffer[i] == 0xA);
+  }
+  PMAJOR("Data check OK!");
+  
+  _mcas->unregister_direct_memory(handle);
+
+  ::free(buffer);
+
+  ASSERT_TRUE(_mcas->close_pool(pool) == S_OK);  
+}
+
+
+TEST_F(mcas_client_test, Release)
+{
+  PLOG("Releasing instance...");
+
+  /* release instance */
+  _mcas.reset(nullptr);
+}
+
+}  // namespace
+
+int main(int argc, char **argv)
+{
+  try {
+    namespace po = boost::program_options;
+    po::options_description desc("Options");
+    desc.add_options()
+      ("help", "Show help")
+      ("debug", po::value<unsigned>()->default_value(0), "Debug level 0-3")
+      ("server-addr", po::value<std::string>()->default_value("10.0.0.101:11911:verbs"), "Server address IP:PORT[:PROVIDER]")
+      ("device", po::value<std::string>()->default_value("mlx5_0"), "Network device (e.g., mlx5_0)")
+      ("pool", po::value<std::string>()->default_value("myPool"), "Pool name")
+      ("value_size", po::value<std::size_t>()->default_value(0), "Value size")
+      ("base", po::value<unsigned>()->default_value(0), "Base core.");
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+
+    if (vm.count("help") > 0) {
+      std::cout << desc;
+      return -1;
+    }
+
+    Options.addr        = vm["server-addr"].as<std::string>();
+    Options.debug_level = vm["debug"].as<unsigned>();
+    Options.pool        = vm["pool"].as<std::string>();
+    Options.device      = vm["device"].as<std::string>();
+    Options.base_core   = vm["base"].as<unsigned>();
+    Options.value_size  = vm["value_size"].as<std::size_t>();
+
+    PLOG("Instantiating..");
+    instantiate();
+    PLOG("Instantiation OK.");
+    
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+  }
+  catch (...) {
+    PLOG("bad command line option configuration");
+    return -1;
+  }
+
+  return 0;
+}

--- a/src/components/client/mcas-client/unit_test/test2.cpp
+++ b/src/components/client/mcas-client/unit_test/test2.cpp
@@ -150,6 +150,7 @@ TEST_F(mcas_client_test, GetDirectWithContent)
 
   /* check content */
   for(size_t i=0;i<size;i++) {
+    if(buffer[i] != 0xA) PWRN("bad data");
     ASSERT_TRUE(buffer[i] == 0xA);
   }
   PMAJOR("Data check OK!");

--- a/src/lib/libnupm/include/nupm/mappers.h
+++ b/src/lib/libnupm/include/nupm/mappers.h
@@ -47,7 +47,7 @@ protected:
   /* Objects not exceeding 8K size are allocated in 1MB pools.
    * Objects exceding 8K are allocated singly.
    */
-  static constexpr size_t L0_MAX_SMALL_OBJECT_SIZE = KiB(8);
+  static constexpr size_t L0_MAX_SMALL_OBJECT_SIZE = KiB(256);
   static constexpr size_t L0_REGION_SIZE           = MiB(1);
 
  public:


### PR DESCRIPTION
128K is sufficient to saturate 100GbE b/w
A better memory non-volatile/reconstituting allocator is needed.