### PR TITLE
Issue #84: mapstore memory fix

### DIFF
--- a/src/components/store/mapstore/src/map_store.h
+++ b/src/components/store/mapstore/src/map_store.h
@@ -24,11 +24,6 @@
 #include <api/kvstore_itf.h>
 
 #define PREFIX "Map_store: "
-/** 
- * Debug level for this component
- * 
- */
-static constexpr unsigned DEBUG_LEVEL = 0;
 
 namespace nupm
 {
@@ -37,8 +32,11 @@ namespace nupm
 
 class Map_store : public component::IKVStore /* generic Key-Value store interface */
 {
+  unsigned _debug_level;
+
 public:
-  static constexpr unsigned debug_level() { return DEBUG_LEVEL; }
+  
+  unsigned debug_level() { return _debug_level; }
 
   /**
    * Constructor
@@ -46,7 +44,7 @@ public:
    * @param block_device Block device interface
    *
    */
-  Map_store(const std::string &owner, const std::string &name);
+  Map_store(const unsigned debug_level, const std::string &owner, const std::string &name);
 
   /**
    * Destructor
@@ -201,17 +199,16 @@ public:
 
   void unload() override { delete this; }
 
-  virtual component::IKVStore *create(unsigned,
-    const IKVStore_factory::map_create &mc) override {
+  virtual component::IKVStore *create(unsigned debug_level,
+                                      const IKVStore_factory::map_create &mc) override
+  {
     auto owner_it = mc.find(+component::IKVStore_factory::k_owner);
     auto name_it = mc.find(+component::IKVStore_factory::k_name);
     component::IKVStore *obj =
-      static_cast<component::IKVStore *>(
-        new Map_store(
-          owner_it == mc.end() ? "owner" : owner_it->second
-          , name_it == mc.end() ? "name" : name_it->second
-        )
-    );
+      static_cast<component::IKVStore *>
+      (new Map_store(debug_level,
+                     owner_it == mc.end() ? "owner" : owner_it->second,
+                     name_it == mc.end() ? "name" : name_it->second));
     assert(obj);
     obj->add_ref();
     return obj;

--- a/src/server/mcas/src/shard.cpp
+++ b/src/server/mcas/src/shard.cpp
@@ -241,9 +241,9 @@ void Shard::thread_entry(const std::string &backend,
 void Shard::initialize_components(const std::string &backend,
                                   const std::string &,  // index
                                   const std::string &dax_config,
-                                  unsigned,  // debug_level
+                                  unsigned debug_level,
                                   const std::string ado_cores,
-                                  float             ado_core_num)
+                                  float ado_core_num)
 {
   using namespace component;
 
@@ -270,16 +270,15 @@ void Shard::initialize_components(const std::string &backend,
     if (backend == "hstore" || backend == "hstore-cc") {
       if (dax_config.empty()) throw General_exception("hstore backend requires dax configuration");
 
-      _i_kvstore.reset(fact->create(0
-                                    , {
-                                       {+component::IKVStore_factory::k_debug, std::to_string(debug_level())}
-                                       , {+component::IKVStore_factory::k_dax_config, dax_config}
+      _i_kvstore.reset(fact->create(debug_level,
+                                    {
+                                     {+component::IKVStore_factory::k_debug, std::to_string(debug_level)},
+                                     {+component::IKVStore_factory::k_dax_config, dax_config}
                                     }
-                                    )
-                       );
+                                    ));
     }
     else {
-      _i_kvstore.reset(fact->create(0, {}));
+      _i_kvstore.reset(fact->create(debug_level, {}));
     }
   }
 
@@ -287,10 +286,11 @@ void Shard::initialize_components(const std::string &backend,
   {
     IBase *comp = load_component("libcomponent-adomgrproxy.so", ado_manager_proxy_factory);
     if (comp) {
-      auto fact = make_itf_ref(static_cast<IADO_manager_proxy_factory *>(comp->query_interface(IADO_manager_proxy_factory::iid())));
+      auto fact = make_itf_ref(static_cast<IADO_manager_proxy_factory *>
+                               (comp->query_interface(IADO_manager_proxy_factory::iid())));
       assert(fact);
 
-      _i_ado_mgr.reset(fact->create(debug_level(), _core, ado_cores, ado_core_num));
+      _i_ado_mgr.reset(fact->create(debug_level, _core, ado_cores, ado_core_num));
 
       if (_i_ado_mgr == nullptr)
         throw General_exception("Instantiation of ADO manager failed unexpectedly.");


### PR DESCRIPTION
Bug fix: hash table memory was being released before the dtor of the _map instance.  This has been modified by using a pointer member which is explicitly dtor'ed before region memory is cleaned up.

Also cleaned up logging (debug_level).

Only happened on pool erasure.