### PR TITLE
MCAS-78: added alignment parameter to IKVStore::lock

### DIFF
--- a/src/components/api/kvstore.h
+++ b/src/components/api/kvstore.h
@@ -561,6 +561,7 @@ protected:
    * @param type STORE_LOCK_READ | STORE_LOCK_WRITE
    * @param out_value [out] Pointer to data
    * @param inout_value_len [in-out] Size of data in bytes
+   * @param inout_alignment [in-out] Alignment in bytes.
    * @param out_key [out]  Handle to key for unlock
    * @param out_key_ptr [out]  Optional request for key-string pointer (set to
    * nullptr if not required)
@@ -575,10 +576,12 @@ protected:
                         const lock_type_t  type,
                         void*&             out_value,
                         size_t&            inout_value_len,
+                        size_t&            inout_alignment,
                         key_t&             out_key_handle,
                         const char**       out_key_ptr = nullptr)
   {
-    return error_value(E_NOT_SUPPORTED, pool, key, type, out_value, inout_value_len, out_key_handle, out_key_ptr);
+    return error_value(E_NOT_SUPPORTED, pool, key, type, out_value, inout_value_len, inout_alignment,
+                       out_key_handle, out_key_ptr);
   }
 
   /**

--- a/src/components/store/hstore/src/hstore.cpp
+++ b/src/components/store/hstore/src/hstore.cpp
@@ -642,6 +642,7 @@ auto hstore::lock(
   , lock_type_t type
   , void *& out_value
   , std::size_t & out_value_len
+  , std::size_t & /*inout_alignment*/
   , key_t& out_key
   , const char ** out_key_ptr
 ) -> status_t

--- a/src/components/store/hstore/src/hstore.h
+++ b/src/components/store/hstore/src/hstore.h
@@ -211,7 +211,8 @@ public:
                 const std::string& key,
                 lock_type_t type,
                 void*& out_value,
-                std::size_t& out_value_len,
+                std::size_t& inout_value_len,
+                std::size_t& inout_value_alignment,
                 key_t& out_key,
                 const char ** out_key_ptr) override;
 

--- a/src/components/store/hstore/unit_test/test1.cpp
+++ b/src/components/store/hstore/unit_test/test1.cpp
@@ -331,7 +331,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     auto lk = IKVStore::key_t();
 
     {
-      auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, value0, value0_len, lk);
+      size_t alignment = 0;
+      auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, value0, value0_len, alignment, lk);
       EXPECT_EQ(S_OK, r);
       EXPECT_NE(nullptr, lk);
       r = _kvstore->put(pool, single_key, single_value.data(), single_value.length());
@@ -371,7 +372,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     std::size_t v_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, alignment, lk);
     EXPECT_EQ(S_OK, r);
     EXPECT_NE(nullptr, v);
     EXPECT_EQ(16, v_len);
@@ -408,7 +410,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     std::size_t v_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, alignment, lk);
     EXPECT_EQ(S_OK, r);
     EXPECT_NE(nullptr, v);
     EXPECT_EQ(single_value.size() / 2, v_len);
@@ -442,7 +445,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     std::size_t v_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, alignment, lk);
     EXPECT_EQ(S_OK, r);
     EXPECT_NE(nullptr, v);
     EXPECT_EQ(single_value.size(), v_len);
@@ -473,7 +477,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     size_t value_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, missing_key, IKVStore::STORE_LOCK_READ, v, value_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, missing_key, IKVStore::STORE_LOCK_READ, v, value_len, alignment, lk);
     EXPECT_EQ(IKVStore::E_KEY_NOT_FOUND, r);
   }
 
@@ -925,7 +930,8 @@ TEST_F(KVStore_test, LockMany)
 
     shared_lock rk0(_kvstore, &pool);
     const char *kf;
-    auto r0 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value0, value0_len, rk0.k, &kf);
+    size_t alignment = 0;
+    auto r0 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value0, value0_len, alignment, rk0.k, &kf);
     EXPECT_EQ(S_OK, r0);
     EXPECT_NE(KEY_NONE, rk0.k);
     if ( S_OK == r0 && IKVStore::KEY_NONE != rk0.k )
@@ -937,7 +943,8 @@ TEST_F(KVStore_test, LockMany)
     void * value1 = nullptr;
     std::size_t value1_len = 0;
     shared_lock rk1(_kvstore, &pool);
-    auto r1 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value1, value1_len, rk1.k, &kf);
+    alignment = 0;
+    auto r1 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value1, value1_len, alignment, rk1.k, &kf);
     EXPECT_EQ(S_OK, r1);
     EXPECT_NE(KEY_NONE, rk1.k);
     if ( S_OK == r1 && IKVStore::KEY_NONE != rk1.k )
@@ -951,7 +958,8 @@ TEST_F(KVStore_test, LockMany)
     void * value2 = nullptr;
     std::size_t value2_len = 0;
     IKVStore::key_t k2 = IKVStore::key_t();
-    auto r2 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_WRITE, value2, value2_len, k2);
+    alignment = 0;
+    auto r2 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_WRITE, value2, value2_len, alignment, k2);
     /* Undocumented behavior: lock conflict returns E_LOCKED */
     EXPECT_EQ(E_LOCKED, r2);
     EXPECT_EQ(KEY_NONE, k2);
@@ -962,7 +970,8 @@ TEST_F(KVStore_test, LockMany)
     {
       const char *kfx;
       exclusive_lock m3(_kvstore, &pool);
-      auto r3 = _kvstore->lock(pool, key_new, IKVStore::STORE_LOCK_WRITE, value3, value3_len, m3.k, &kfx);
+      alignment = 0;
+      auto r3 = _kvstore->lock(pool, key_new, IKVStore::STORE_LOCK_WRITE, value3, value3_len, alignment, m3.k, &kfx);
       /* Used to return S_OK; no longer does so */
       EXPECT_EQ(S_OK_CREATED, r3);
       EXPECT_NE(KEY_NONE, m3.k);

--- a/src/components/store/hstore/unit_test/test1s.cpp
+++ b/src/components/store/hstore/unit_test/test1s.cpp
@@ -300,7 +300,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     auto lk = IKVStore::key_t();
 
     {
-      auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, value0, value0_len, lk);
+      size_t alignment = 0;
+      auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, value0, value0_len, alignment, lk);
       EXPECT_EQ(S_OK, r);
       EXPECT_NE(nullptr, lk);
       r = _kvstore->put(pool, single_key, single_value.data(), single_value.length());
@@ -340,7 +341,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     std::size_t v_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, alignment, lk);
     EXPECT_EQ(S_OK, r);
     EXPECT_NE(nullptr, v);
     EXPECT_EQ(16, v_len);
@@ -377,7 +379,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     std::size_t v_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, alignment, lk);
     EXPECT_EQ(S_OK, r);
     EXPECT_NE(nullptr, v);
     EXPECT_EQ(single_value.size() / 2, v_len);
@@ -412,7 +415,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     std::size_t v_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, single_key, IKVStore::STORE_LOCK_READ, v, v_len, alignment, lk);
     EXPECT_EQ(S_OK, r);
     EXPECT_NE(nullptr, v);
     EXPECT_EQ(single_value.size(), v_len);
@@ -443,7 +447,8 @@ TEST_F(KVStore_test, BasicPutLocked)
     void *v = nullptr;
     size_t value_len = 0;
     auto lk = IKVStore::key_t();
-    auto r = _kvstore->lock(pool, missing_key, IKVStore::STORE_LOCK_READ, v, value_len, lk);
+    size_t alignment = 0;
+    auto r = _kvstore->lock(pool, missing_key, IKVStore::STORE_LOCK_READ, v, value_len, alignment, lk);
     EXPECT_EQ(IKVStore::E_KEY_NOT_FOUND, r);
   }
 
@@ -864,7 +869,8 @@ TEST_F(KVStore_test, LockMany)
 
     /* Lock existing, unlocked value */
     shared_lock rk0(_kvstore, &pool);
-    auto r0 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value0, value0_len, rk0.k);
+    size_t alignment = 0;
+    auto r0 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value0, value0_len, alignment, rk0.k);
     EXPECT_EQ(S_OK, r0);
     EXPECT_NE(KEY_NONE, rk0.k);
     if ( S_OK == r0 && IKVStore::KEY_NONE != rk0.k )
@@ -877,7 +883,8 @@ TEST_F(KVStore_test, LockMany)
     void * value1 = nullptr;
     std::size_t value1_len = 0;
     shared_lock rk1(_kvstore, &pool);
-    auto r1 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value1, value1_len, rk1.k);
+    alignment = 0;
+    auto r1 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_READ, value1, value1_len, alignment, rk1.k);
     EXPECT_EQ(S_OK, r1);
     EXPECT_NE(KEY_NONE, rk1.k);
     if ( S_OK == r1 && IKVStore::KEY_NONE != rk1.k )
@@ -892,7 +899,8 @@ TEST_F(KVStore_test, LockMany)
     void * value2 = nullptr;
     std::size_t value2_len = 0;
     IKVStore::key_t k2 = IKVStore::key_t();
-    auto r2 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_WRITE, value2, value2_len, k2);
+    alignment = 0;
+    auto r2 = _kvstore->lock(pool, key, IKVStore::STORE_LOCK_WRITE, value2, value2_len, alignment, k2);
     /* Undocumented behavior: lock conflict returns E_LOCKED */
     EXPECT_EQ(E_LOCKED, r2);
     EXPECT_EQ(KEY_NONE, k2);
@@ -903,8 +911,9 @@ TEST_F(KVStore_test, LockMany)
     const auto key_new = std::get<0>(kv) + "x";
     try
     {
+      alignment = 0;
       exclusive_lock m3(_kvstore, &pool);
-      auto r3 = _kvstore->lock(pool, key_new, IKVStore::STORE_LOCK_WRITE, value3, value3_len, m3.k);
+      auto r3 = _kvstore->lock(pool, key_new, IKVStore::STORE_LOCK_WRITE, value3, value3_len, alignment, m3.k);
       /* Used to return S_OK; no longer does so */
       EXPECT_EQ(S_OK_CREATED, r3);
       EXPECT_NE(KEY_NONE, m3.k);

--- a/src/components/store/mapstore/CMakeLists.txt
+++ b/src/components/store/mapstore/CMakeLists.txt
@@ -16,12 +16,14 @@ include_directories(${CMAKE_SOURCE_DIR}/src/lib/libnupm/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/components)
 include_directories(${CMAKE_SOURCE_DIR}/src/mm)
 include_directories(${CMAKE_SOURCE_DIR}/src/lib/cityhash/cityhash/src)
-include_directories(${CMAKE_SOURCE_DIR}/src/lib/tbb/include)
+#include_directories(${CMAKE_SOURCE_DIR}/src/lib/tbb/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 link_directories(${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}) # tbb tbbmalloc
 link_directories(${CMAKE_INSTALL_PREFIX}/lib) # tbb tbbmalloc
 
 file(GLOB SOURCES src/*.c*)
+configure_file(src/map_store_env.h.in ${CMAKE_CURRENT_BINARY_DIR}/map_store_env.h)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 target_compile_options(${PROJECT_NAME} PUBLIC "-fPIC")

--- a/src/components/store/mapstore/src/map_store.h
+++ b/src/components/store/mapstore/src/map_store.h
@@ -22,6 +22,7 @@
 #define __MAP_STORE_COMPONENT_H__
 
 #include <api/kvstore_itf.h>
+#include "map_store_env.h"
 
 #define PREFIX "Map_store: "
 
@@ -121,9 +122,12 @@ public:
                              const std::string key0,
                              const std::string key1) override;
 
-  virtual status_t lock(const pool_t pool, const std::string &key,
-                        lock_type_t type, void *&out_value,
-                        size_t &out_value_len,
+  virtual status_t lock(const pool_t pool,
+                        const std::string &key,
+                        lock_type_t type,
+                        void *&out_value,
+                        size_t &inout_value_len,
+                        size_t &inout_alignment,
                         IKVStore::key_t &out_key,
                         const char ** out_key_ptr) override;
 
@@ -212,7 +216,7 @@ public:
     component::IKVStore *obj =
       static_cast<component::IKVStore *>
       (new Map_store(debug_level,
-                     mm_plugin_path_it == mc.end() ? "plugin-path-none" : mm_plugin_path_it->second,
+                     mm_plugin_path_it == mc.end() ? DEFAULT_MM_PLUGIN_PATH : mm_plugin_path_it->second,
                      owner_it == mc.end() ? "owner" : owner_it->second,
                      name_it == mc.end() ? "name" : name_it->second));
     assert(obj);

--- a/src/components/store/mapstore/src/map_store_env.h.in
+++ b/src/components/store/mapstore/src/map_store_env.h.in
@@ -1,0 +1,8 @@
+#ifndef __MAPSTORE_ENV_H__
+#define __MAPSTORE_ENV_H__
+
+#define DEFAULT_MM_PLUGIN_PATH "@CMAKE_BINARY_DIR@/src/mm/rcalb/libmm-plugin-rcalb.so"
+/* experimental option */
+//#define DEFAULT_MM_PLUGIN_PATH "@CMAKE_BINARY_DIR@/src/mm/jemalloc/libmm-plugin-jemalloc.so"
+
+#endif

--- a/src/lib/libccpm/unit_test/test5.cpp
+++ b/src/lib/libccpm/unit_test/test5.cpp
@@ -147,8 +147,9 @@ TEST_F(Log_test, CCBitset)
 	std::size_t heap_size = MiB(5);
 	component::IKVStore::key_t heap_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, heap_lock);
+		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, alignment, heap_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -158,8 +159,9 @@ TEST_F(Log_test, CCBitset)
 	std::size_t bitset_size = sizeof(cc_bitset);
 	component::IKVStore::key_t container_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE, bitset_area, bitset_size, container_lock);
+		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE, bitset_area, bitset_size, alignment, container_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -249,8 +251,9 @@ TEST_F(Log_test, CCVectorOfComposite)
 	std::size_t heap_size = MiB(5);
 	component::IKVStore::key_t heap_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, heap_lock);
+		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, alignment, heap_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -264,8 +267,9 @@ TEST_F(Log_test, CCVectorOfComposite)
 	std::size_t vector_size = sizeof(cc_vector);
 	component::IKVStore::key_t container_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE, vector_area, vector_size, container_lock);
+		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE, vector_area, vector_size, alignment, container_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -402,8 +406,9 @@ TEST_F(Log_test, CCVector)
 	std::size_t heap_size = MiB(5);
 	component::IKVStore::key_t heap_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, heap_lock);
+		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, alignment, heap_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -414,8 +419,9 @@ TEST_F(Log_test, CCVector)
 	std::size_t vector_size = sizeof(cc_vector);
 	component::IKVStore::key_t container_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE, vector_area, vector_size, container_lock);
+		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE, vector_area, vector_size, alignment, container_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -539,8 +545,9 @@ TEST_F(Log_test, CCList)
 	std::size_t heap_size = MiB(5);
 	component::IKVStore::key_t heap_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, heap_lock);
+		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, alignment, heap_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -551,8 +558,9 @@ TEST_F(Log_test, CCList)
 	std::size_t list_size = sizeof(cc_list);
 	component::IKVStore::key_t list_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "list", component::IKVStore::STORE_LOCK_WRITE, list_area, list_size, list_lock);
+		auto r = kvstore->lock(pool, "list", component::IKVStore::STORE_LOCK_WRITE, list_area, list_size, alignment, list_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -669,8 +677,9 @@ TEST_F(Log_test, CCListOfPointer)
 	std::size_t heap_size = MiB(5);
 	component::IKVStore::key_t heap_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, heap_lock);
+		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, alignment, heap_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -681,8 +690,9 @@ TEST_F(Log_test, CCListOfPointer)
 	std::size_t list_size = sizeof(cc_list);
 	component::IKVStore::key_t list_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "list", component::IKVStore::STORE_LOCK_WRITE, list_area, list_size, list_lock);
+		auto r = kvstore->lock(pool, "list", component::IKVStore::STORE_LOCK_WRITE, list_area, list_size, alignment, list_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -805,8 +815,9 @@ TEST_F(Log_test, CCListOfSharedPointer)
 	std::size_t heap_size = MiB(5);
 	component::IKVStore::key_t heap_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, heap_lock);
+		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, alignment, heap_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -817,8 +828,9 @@ TEST_F(Log_test, CCListOfSharedPointer)
 	std::size_t list_size = sizeof(cc_list);
 	component::IKVStore::key_t list_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "list", component::IKVStore::STORE_LOCK_WRITE, list_area, list_size, list_lock);
+		auto r = kvstore->lock(pool, "list", component::IKVStore::STORE_LOCK_WRITE, list_area, list_size, alignment, list_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 

--- a/src/lib/libccpm/unit_test/test6.cpp
+++ b/src/lib/libccpm/unit_test/test6.cpp
@@ -147,7 +147,9 @@ TEST_F(Log_test, CCVectorOfPointer)
 	component::IKVStore::key_t heap_lock{};
 	{
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE, heap_area, heap_size, heap_lock);
+    size_t alignment = 0;
+		auto r = kvstore->lock(pool, "heap", component::IKVStore::STORE_LOCK_WRITE,
+                           heap_area, heap_size, alignment, heap_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 
@@ -161,8 +163,10 @@ TEST_F(Log_test, CCVectorOfPointer)
 	std::size_t vector_size = sizeof(cc_vector);
 	component::IKVStore::key_t container_lock{};
 	{
+    size_t alignment = 0;
 		/* An odd "insert or locate" interface. */
-		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE, vector_area, vector_size, container_lock);
+		auto r = kvstore->lock(pool, "vector", component::IKVStore::STORE_LOCK_WRITE,
+                           vector_area, vector_size, alignment, container_lock);
 		ASSERT_EQ(S_OK_CREATED, r);
 	}
 


### PR DESCRIPTION
Additional of alignment parameter for IKVStore::lock.
Implementation in mapstore only.
Prior use-cases set to default of 0 alignment (i.e. no alignment).
